### PR TITLE
[Fix] dtype of classes

### DIFF
--- a/openpack_toolkit/__init__.py
+++ b/openpack_toolkit/__init__.py
@@ -2,7 +2,7 @@
 .. include:: ../README.md
 """
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 from . import codalab, configs, data, utils
 from .activity import ActClass, ActSet
 from .configs.datasets.annotations import OPENPACK_OPERATIONS

--- a/openpack_toolkit/configs/_schema.py
+++ b/openpack_toolkit/configs/_schema.py
@@ -104,7 +104,7 @@ class DatasetConfig:
     stream: Optional[DataStreamConfig] = None
     split: DataSplitConfig = MISSING
     annotation: AnnotConfig = MISSING
-    classes: Optional[Label] = MISSING
+    classes: Optional[List[Label]] = MISSING
 
 
 # =========

--- a/tests/configs/test_schema.py
+++ b/tests/configs/test_schema.py
@@ -15,7 +15,12 @@ from openpack_toolkit.configs._schema import (
     SessionConfig,
     UserConfig,
 )
-from openpack_toolkit.configs.datasets.annotations import OPENPACK_OPERATIONS
+from openpack_toolkit.configs.datasets.annotations import (
+    OPENPACK_OPERATIONS,
+    OPENPACK_OPERATIONS_1HZ_ANNOTATION,
+)
+from openpack_toolkit.configs.datasets.splits import PILOT_CHALLENGE_SPLIT
+from openpack_toolkit.configs.datasets.streams import ATR_ACC_STREAM
 
 
 @pytest.fixture()
@@ -109,9 +114,9 @@ def test_OpenPackConfig__01(split_conf, annot_conf):
     dataset_conf = DatasetConfig(
         name="test",
         streams=None,
-        stream=None,
-        split=split_conf,
-        annotation=annot_conf,
+        stream=ATR_ACC_STREAM,
+        split=PILOT_CHALLENGE_SPLIT,
+        annotation=OPENPACK_OPERATIONS_1HZ_ANNOTATION,
         classes=OPENPACK_OPERATIONS,
     )
 

--- a/tests/configs/test_schema.py
+++ b/tests/configs/test_schema.py
@@ -15,6 +15,7 @@ from openpack_toolkit.configs._schema import (
     SessionConfig,
     UserConfig,
 )
+from openpack_toolkit.configs.datasets.annotations import OPENPACK_OPERATIONS
 
 
 @pytest.fixture()
@@ -111,6 +112,7 @@ def test_OpenPackConfig__01(split_conf, annot_conf):
         stream=None,
         split=split_conf,
         annotation=annot_conf,
+        classes=OPENPACK_OPERATIONS,
     )
 
     conf = OpenPackConfig(

--- a/tests/test_openpack_toolkit.py
+++ b/tests/test_openpack_toolkit.py
@@ -2,4 +2,4 @@ from openpack_toolkit import __version__
 
 
 def test_version():
-    assert __version__ == '1.0.0'
+    assert __version__ == '1.0.1'


### PR DESCRIPTION
# Overview 

Data type of `DatasetConfig.classes` was wrong. It should be a list of `Label`.
This PR fixes this bug.

# Updates 

- 🐛: Fix data type of `Dtype of `DatasetConfig.classes` .
- 📂 : Release `v1.0.1` 


# How to use?

```python
from openpack_toolkit.configs.datasets.annotations import (
    OPENPACK_OPERATIONS,
    OPENPACK_OPERATIONS_1HZ_ANNOTATION,
)
from openpack_toolkit.configs.datasets.splits import PILOT_CHALLENGE_SPLIT
from openpack_toolkit.configs.datasets.streams import ATR_ACC_STREAM

dataset_conf = DatasetConfig(
        name="test",
        streams=None,
        stream=ATR_ACC_STREAM,
        split=PILOT_CHALLENGE_SPLIT,
        annotation=OPENPACK_OPERATIONS_1HZ_ANNOTATION,
        classes=OPENPACK_OPERATIONS,
)
```

